### PR TITLE
Feat/no token

### DIFF
--- a/deploy_params.example.js
+++ b/deploy_params.example.js
@@ -5,9 +5,9 @@ const ETHERSCAN_API_KEY = "";
 
 const MOLOCH_ADDRESS = "DEPLOY_FRESH"; // for local test net deployments
 // const MOLOCH_ADDRESS = "0x501f352e32ec0c981268dc5b5ba1d3661b1acbc6"; // kovan moloch
+const DIST_TOKEN_ADDRESS = "0x3202Fe1B3A4a0B79bdE96Ae9670b613f5f50cBe7";
 const CAP_TOKEN_ADDRESS = "0xd0a1e359811322d97991e03f863a0c30c2cf029c"; // kovan weth
 const VESTING_PERIOD = oneYear;
-const HAUS_TOKEN_SYMBOL = "SYM";
 const TOKEN_DIST = {
   transmutationDist: 100000,
   trustDist: 50000,

--- a/test/utils/constants.ts
+++ b/test/utils/constants.ts
@@ -40,10 +40,13 @@ const revertStrings = {
     BALANCE: "Transmutation::insufficient-balance"
   },
   factory: {
-    BAD_DISTRIBUTION: "Factory::invalid-vesting-dist"
+    BAD_VESTING_DIST: "Factory::invalid-vesting-dist",
+    BAD_TOKEN_DIST: "Factory::invalid-token-dist",
+    FAILED_DIST: "Factory::failed-distribution"
   },
   token: {
-    BALANCE: "ERC20: transfer amount exceeds balance"
+    BALANCE: "ERC20: transfer amount exceeds balance",
+    ALLOWANCE: "ERC20: transfer amount exceeds allowance"
   }
 }
 


### PR DESCRIPTION
Instead of deploying a token from the factory, use a previously deployed token. The caller of `Factory.deployAll` must have enough tokens to cover all of the token distributions and approve the factory to transfer the tokens.