### PR TITLE
Modify Factory.deployAll to avoid ABIEncoderV2

### DIFF
--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -1,5 +1,4 @@
 pragma solidity 0.5.11;
-pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -17,18 +16,14 @@ contract Factory {
         address trust
     );
 
-    struct TokenDistribution {
-        uint256 transmutationDist;
-        uint256 trustDist;
-        uint256 minionDist;
-    }
-
     function deployAll(
         address _moloch,
         address _capitalToken,
         address _distributionToken,
         uint256 _vestingPeriod,
-        TokenDistribution calldata _dist,
+        uint256 _transmutationDist,
+        uint256 _trustDist,
+        uint256 _minionDist,
         address[] calldata _vestingDistRecipients,
         uint256[] calldata _vestingDistAmts
     )
@@ -72,17 +67,17 @@ contract Factory {
         IERC20(_distributionToken).transferFrom(
             msg.sender,
             minion,
-            _dist.minionDist
+            _minionDist
         );
         IERC20(_distributionToken).transferFrom(
             msg.sender,
             trust,
-            _dist.trustDist
+            _trustDist
         );
         IERC20(_distributionToken).transferFrom(
             msg.sender,
             transmutation,
-            _dist.transmutationDist
+            _transmutationDist
         );
     }
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -12,9 +12,9 @@ task("deployToken", "Deploys a token and mints sum(TOKEN_DIST) to deployrer")
   .addParam("mnemonic", "mnemonic to use for deployment")
   .addParam("symbol", "Symbol to deploy the token with")
   .setAction(async (args, bre) => {
-    await bre.run("compile");
+    await bre.run("compile-flat");
 
-    const tokenPath = "../artifacts/Token.json";
+    const tokenPath = "../artifacts-flattened/Token.json";
     const Token: any = await import(tokenPath);
 
     // --- Get provider and deployer wallet ---
@@ -67,13 +67,11 @@ task("deployToken", "Deploys a token and mints sum(TOKEN_DIST) to deployrer")
 task("deploy", "Deploys factory and uses factory.deployAll to deploy system")
   .addParam("mnemonic", "mnemonic to use for deployment")
   .setAction(async (args, bre) => {
-    /* await bre.run("compile-flat"); */
-    await bre.run("compile");
+    await bre.run("compile-flat");
 
-    /* const factoryPath = "../artifacts-flattened/Factory.json"; */
-    const factoryPath = "../artifacts/Factory.json";
-    const tokenPath = "../artifacts/Token.json";
-    const molochPath = "../artifacts/Moloch.json";
+    const factoryPath = "../artifacts-flattened/Factory.json";
+    const tokenPath = "../artifacts-flattened/Token.json";
+    const molochPath = "../artifacts-flattened/Moloch.json";
     const Factory: any = await import(factoryPath);
     const Token: any = await import(tokenPath);
     const Moloch: any = await import(molochPath);
@@ -222,7 +220,9 @@ task("deploy", "Deploys factory and uses factory.deployAll to deploy system")
       params.CAP_TOKEN_ADDRESS,
       params.DIST_TOKEN_ADDRESS,
       params.VESTING_PERIOD,
-      params.TOKEN_DIST,
+      params.TOKEN_DIST.transmutationDist,
+      params.TOKEN_DIST.trustDist,
+      params.TOKEN_DIST.minionDist,
       params.VESTING_DIST.recipients,
       params.VESTING_DIST.amts,
     );

--- a/test/factory.spec.ts
+++ b/test/factory.spec.ts
@@ -67,9 +67,9 @@ describe("Factory", () => {
   describe("deployAll()", () => {
 
     const dist = {
-      minionDist: 100,
       transmutationDist: 10,
-      trustDist: 5
+      trustDist: 5,
+      minionDist: 100
     };
 
     it("reverts if vesting distribution lengths don't match", async () => {
@@ -80,7 +80,9 @@ describe("Factory", () => {
           capTok.address,
           distTok.address,
           C.oneYear,
-          dist,
+          dist.transmutationDist,
+          dist.trustDist,
+          dist.minionDist,
           C.vestingDistribution.recipients,
           C.vestingDistribution.amts.slice(1)
         )
@@ -93,7 +95,9 @@ describe("Factory", () => {
           capTok.address,
           distTok.address,
           C.oneYear,
-          dist,
+          dist.transmutationDist,
+          dist.trustDist,
+          dist.minionDist,
           C.vestingDistribution.recipients.slice(1),
           C.vestingDistribution.amts
         )
@@ -109,7 +113,9 @@ describe("Factory", () => {
           capTok.address,
           distTok.address,
           C.oneYear,
-          dist,
+          dist.transmutationDist,
+          dist.trustDist,
+          dist.minionDist,
           C.vestingDistribution.recipients,
           C.vestingDistribution.amts
         )
@@ -125,7 +131,9 @@ describe("Factory", () => {
         capTok.address,
         distTok.address,
         C.oneYear,
-        dist,
+        dist.transmutationDist,
+        dist.trustDist,
+        dist.minionDist,
         C.vestingDistribution.recipients,
         C.vestingDistribution.amts
       );


### PR DESCRIPTION
Due to an obscure solc bug that prevents the Transmutation contract from being compiled with ABIEncoderV2 enabled, the flattened contracts could not be compiled without removing ABIEncoderV2 from the Factory.